### PR TITLE
docs(economics): v3 refresh — offline model, 12wk snapshots, n-sensitivity, year-0 breakeven

### DIFF
--- a/miner-economics/MINER-ECONOMICS.md
+++ b/miner-economics/MINER-ECONOMICS.md
@@ -183,3 +183,53 @@ Take this model to 1–2 people who've done PoS / mining economics before (Cosmo
 If 2 out of 2 say "this doesn't close without redesigning emissions or finding demand," then Gap C has failed and the 42-CORE-GAPS kill criteria triggers at the T+4 week mark.
 
 If at least one sees a plausible path, we scope the redesign and keep going.
+
+---
+
+## v3 refresh (2026-07-04)
+
+> Refresh per Phase 1.1 of `44-L1-MASTER-PLAN-CN.md`. Model: [`refresh.py`](./refresh.py) (offline, stdlib-only); tables regenerated in [`OUTPUT.md`](./OUTPUT.md). Everything above this section is the v2 analysis, kept as-is for the record.
+
+### Data-quality caveat — read this before the numbers
+
+Unlike v2, this refresh does **not** query the live RPC. The testnet has been in a 3-way consensus fork (three validators, three independent chains) for the entire snapshot period, and was hard-reset with fresh genesis on **2026-06-18** and again on **2026-06-27**. Every number below comes from `snapshots.jsonl` — 12 weekly Gap C snapshots (2026-04-13 → 2026-06-28) — and each snapshot reflects whichever forked node answered that week. The `all_time_*` counters are visibly discontinuous (548,504 on 05-17 → 131,495 on 06-07 → 22,931 on 06-21 → 6,790 on 06-28), 4 of 12 snapshots are all-zero (RPC down or node mid-reset), and on 06-28 both miners report identical task counts and earnings — plausibly the same task queue served on separate fork branches, i.e. some double-counting. I treat the series as **indicative, not authoritative**. Live numbers would be worse, not better: they'd be authoritative-looking and still wrong.
+
+### What changed vs v2
+
+1. **Twelve weeks of observation instead of a single-day measurement.** The three pre-fork snapshots (April) were remarkably stable: ~17,280 tasks/day, ~6,700 QFC/day pool, fee share 25.6–26.2% — v2's 25% assumption was accurate when the chain was healthy.
+2. **Fee share observed at 0.29 on 06-28** vs 0.25 assumed in v2. Before celebrating: it rose for the *wrong reason*. Fees didn't grow — the inflation-side pool shrank (4,990 → 3,324 QFC/day) because the forked chain produces blocks erratically. Demand-funded progress looks identical to supply-side decay in this one ratio; the decomposition matters.
+3. **miners_registered went 3 → 0 → 2** across the resets. The two survivors (`0xdb7c460a…`, `0xca8d86c4…`) re-registered after the 06-27 reset; the third address (`0x31ca8b60…`) never earned anything in any snapshot and is gone. n=2 is today's real miner count, so the tables now start at n=2.
+4. **Model basis changed.** v2 modeled the single active miner's earnings as the pool; v3 uses the network-wide miner reward pool from the 06-28 snapshot (4,681.69 QFC/day = 3,323.69 inflation + 1,358 fees), splits it 1/n, and decays the inflation slice on the halving schedule. The n=2 year-0 cell reproduces the observed per-miner 2,340.84 QFC/day to within 0.1%, which is the one consistency check the forked data allows.
+5. **Constants re-verified** against `qfc-core/crates/qfc-types/src/constants.rs` (2026-07-04): 10 QFC/block, yearly halving, 0.625 floor — unchanged. One thing I hadn't recorded in v2: the protocol *gas*-fee split (47/28/20/5 producer/voters/burn/treasury) allocates **0% to inference miners**. Miner fee income is exclusively inference task fees (`maxFee`, 0.1 QFC/task), a separate flow. The model was already treating it that way, but now it's explicit.
+
+### Does "conditional pass" still hold?
+
+**Yes.** The verdict rested on a structural fact — the emission schedule sunsets itself — and that fact is protocol code, not testnet telemetry. At the refreshed baseline and *zero* demand growth, the miner-pool fee share goes 29% (Y0) → 45% (Y1) → 62% (Y2) → 87% (Y4) purely from halving. The chain becomes demand-funded on schedule even if demand never grows, at the cost of the pool shrinking to a third of today.
+
+The master plan's abandonment gate was "refresh concludes token price > $10 needed for anyone to run." The worst realistic cell is a rented datacenter GPU at n=1,000 needing $2.11 — bad, but an order of magnitude inside the gate, and nobody should run rented A100s on this chain anyway. The gate does not trigger.
+
+What the refresh *does* sharpen: the demand side got worse, not better. `unique_submitters_last_100` is now 0 (was 2–3 internal in April). There are not even internal-looking submitters in the window anymore; the 13,580 tasks/day are pure self-generated load. Gap B remains the actual existential issue — this model just prices what miners earn while we wait.
+
+### The two survival conditions, restated with refreshed numbers
+
+1. **Miners must survive year 0 on 1/n of a 4,682 QFC/day pool.** Refreshed breakevens (Y0): at n=100, an RTX 3060 rig needs ≥ **$0.021** (v2 said $0.032 — looks better only because the pool basis changed); at n=500 it needs **$0.105** and at n=1,000 **$0.211**. Idle VPS needs $0.0035 / $0.018 / $0.035 at n=100/500/1,000; an already-owned laptop is free at any n. The v2 conclusion stands, slightly sharpened: **below ~$0.02/QFC, only $0-marginal hardware should be onboarded past n≈100**, and GPU recruitment before a price floor exists is how we churn early miners.
+2. **Demand must show up before miner count grows past ~500.** At n=500, year 0, the per-miner reward is 9.36 QFC/day — $0.47/day at $0.05. That covers a VPS ($0.16/day) and nothing else. By year 1 it's 6.04 QFC/day. Unless task fees grow several-fold by then, every miner beyond the hobbyist tier at n≥500 is underwater at any price below $0.10. Pace of onboarding still matters more than total count.
+
+### What this refresh cannot tell us
+
+- Whether the April-era ~17k tasks/day or the post-reset 13.6k/day is the "real" steady state — both are internal load generators, on a forked chain.
+- Anything about PoC weighting in practice: with 2 miners splitting exactly 50/50, the 1/n assumption is untested above n=2.
+- Whether the theoretical inference-miner pool (15% of block rewards ≈ 38,900 QFC/day at nominal 3.333 s blocks) would be reached on a healthy chain — observed is ~12× lower. If the consensus fix lands and block production normalizes, the year-0 pool could be substantially *larger* than modeled here, which would loosen condition 1 and tighten nothing. Re-run `refresh.py` against the first month of post-fix snapshots before quoting these tables externally.
+
+Next step is unchanged and is not a modeling step: **1.3 — put this in front of one or two people who have done PoS/DePIN economics** (REVIEW-REQUEST.md is written; it needs to be sent). The refresh strengthens the case that the question for them is the ramp math, not existential doom.
+
+### How to reproduce (v3)
+
+```bash
+cd qfc-design/miner-economics
+python3 refresh.py            # Markdown tables to stdout
+python3 refresh.py --write    # regenerate OUTPUT.md
+python3 refresh.py --json     # raw numbers
+```
+
+No network access required or wanted — the model reads `snapshots.jsonl` and hard-codes the verified protocol constants, with sanity checks (`## Sanity checks` in OUTPUT.md) asserting internal consistency on every run.

--- a/miner-economics/OUTPUT.md
+++ b/miner-economics/OUTPUT.md
@@ -1,110 +1,106 @@
-## Emission schedule (from protocol constants)
+# QFC Miner Economics — model output (v3, 2026-07-04)
 
-| Year | QFC/block | Blocks/day | QFC/day network-wide |
-|-----:|----------:|-----------:|---------------------:|
-| 0 |   10.0000 | 4,547 |               45,470 |
-| 1 |    5.0000 | 4,547 |               22,735 |
-| 2 |    2.5000 | 4,547 |               11,368 |
-| 3 |    1.2500 | 4,547 |                5,684 |
-| 4 |    0.6250 | 4,547 |                2,842 |
-| 5 |    0.6250 | 4,547 |                2,842 |
+> Generated offline — no live RPC (testnet is in a 3-way consensus fork; live numbers are unreliable).
+> Command: `cd miner-economics && python3 refresh.py --write`
+> Inputs: `snapshots.jsonl` (12 weekly Gap C snapshots, 2026-04-13 → 2026-06-28) + protocol constants verified against `qfc-core/crates/qfc-types/src/constants.rs`.
 
-Floor: 0.625 QFC/block after year 4. Block time: 19s measured on testnet.
+> **Data-quality caveat:** the chain was hard-reset with fresh genesis on 2026-06-18 and again on 2026-06-27, and has run as 3 independent forked chains for the whole snapshot period. `all_time_*` counters are discontinuous and each snapshot reflects whichever forked node answered. Treat the series as indicative, not authoritative.
 
-**Implication for the 75/25 baseline:** today's inflation subsidy is year-0 emission. By year 4 the absolute QFC subsidy is 1/16 of today. If task volume grows even 4× by year 4 at today's 0.1 QFC/task fee, fees surpass inflation and the chain becomes demand-funded without any parameter change. The question is whether demand shows up.
+## Snapshot series (12 weeks)
 
-## Baseline (measured, 2026-04-14)
+| Date | Miners reg. | Tasks/day | Earnings QFC/day | Fee share | All-time tasks | Note |
+|------|------------:|----------:|-----------------:|----------:|---------------:|------|
+| 2026-04-13 | 3 | 17,280 | 6,718 | 25.7% | 259,287 |  |
+| 2026-04-19 | 3 | 17,280 | 6,607 | 26.2% | 306,420 |  |
+| 2026-04-26 | 3 | 17,278 | 6,758 | 25.6% | 366,921 |  |
+| 2026-05-03 | 0 | 0 | 0 | — | 0 | RPC down / node reset — all zeros |
+| 2026-05-10 | 0 | 0 | 0 | — | 0 | RPC down / node reset — all zeros |
+| 2026-05-17 | 3 | 17,276 | 6,707 | 25.8% | 548,504 |  |
+| 2026-05-24 | 0 | 0 | 0 | — | 0 | RPC down / node reset — all zeros |
+| 2026-05-31 | 0 | 0 | 0 | — | 0 | RPC down / node reset — all zeros |
+| 2026-06-07 | 0 | 0 | 0 | — | 131,495 | validators up, miners deregistered; all_time reset ~06-05 |
+| 2026-06-14 | 0 | 0 | 0 | — | 192,093 | same — no miner earnings |
+| 2026-06-21 | 0 | 0 | 0 | — | 22,931 | post 06-18 genesis reset; counter restarted |
+| 2026-06-28 | 2 | 13,580 | 4,682 | 29.0% | 6,790 | post 06-27 genesis reset; **baseline for v3** |
 
-- Active miners: 1 (miner `0xdb7c460a...`, single one running tasks)
-- Daily reward: **3,427 QFC/day**
-- Daily tasks: 8,635
-- Implied inflation subsidy: 2,563 QFC/day
-- Implied fees captured: 864 QFC/day
-- Submitters observed: 2 addresses (internal, not external users yet)
+Only 5 of 12 snapshots are usable (non-zero). Observed fee share across usable snapshots: 0.256–0.290 (v2 assumed 0.25).
 
-## Scenario: daily reward per miner (QFC)
+## Baseline (latest usable snapshot: 2026-06-28)
 
-Task demand held constant at measured baseline (8,635/day). Inflation pool split 1/n.
+- Active miners: **2** (both earning identical amounts — even split)
+- Network miner reward pool: **4,681.69 QFC/day**
+- Daily tasks: 13,580 (sum of per-miner counts; both miners report the same 6,790 — possible fork double-count)
+- Fee slice: 1,358.0 QFC/day (29% of reward; fee = 0.1 QFC/task)
+- Inflation slice: 3,323.69 QFC/day
+- External paying users: still **zero** (`unique_submitters_last_100` = 0)
 
-| Miners | Inflation share | Fee share | Total QFC/day |
-|-------:|----------------:|----------:|--------------:|
-|      1 |        2,563.41 |    863.50 |      3,426.91 |
-|     10 |          256.34 |     86.35 |        342.69 |
-|    100 |           25.63 |      8.63 |         34.27 |
-|    500 |            5.13 |      1.73 |          6.85 |
-|  1,000 |            2.56 |      0.86 |          3.43 |
-| 10,000 |            0.26 |      0.09 |          0.34 |
+Model basis (changed vs v2): pool = network-wide miner rewards from this snapshot. Inflation slice scales with the halving schedule; fee slice held at observed demand (no growth assumed). Split 1/n across miners.
 
-## Scenario: USD daily profit per miner
+## Emission schedule (protocol constants)
 
-Rows = token price. Columns = miner count. Inner values = daily profit in USD, assuming:
+| Year | QFC/block | × of Y0 | Miner inflation pool QFC/day | Fee share at constant demand |
+|-----:|----------:|--------:|-----------------------------:|-----------------------------:|
+| 0 | 10.0000 | 1.0000 | 3,323.7 | 29.0% |
+| 1 | 5.0000 | 0.5000 | 1,661.8 | 45.0% |
+| 2 | 2.5000 | 0.2500 | 830.9 | 62.0% |
+| 3 | 1.2500 | 0.1250 | 415.5 | 76.6% |
+| 4 | 0.6250 | 0.0625 | 207.7 | 86.7% |
+| 5 | 0.6250 | 0.0625 | 207.7 | 86.7% |
 
-- RTX 3060 rig (180W, amort $167/yr)
-- $0.15/kWh electricity
+Nominal block time 3333 ms and 15% inference-miner share imply a theoretical Y0 miner pool of 38,884 QFC/day — the observed pool is far below that because the forked chain produces blocks erratically. The model uses the *observed* pool.
 
-Daily opex = $1.10 (electricity $0.65 + amort $0.46)
+## Per-miner daily reward (QFC/day), by miner count × year
 
-| Token $ | n=1 | n=10 | n=100 | n=500 | n=1,000 | n=10,000 |
-|---------|--------|--------|--------|--------|--------|--------|
-| $ 0.001 |   +2.32 |   -0.76 |   -1.07 |   -1.10 |   -1.10 |   -1.10 |
-| $ 0.010 |  +33.16 |   +2.32 |   -0.76 |   -1.04 |   -1.07 |   -1.10 |
-| $ 0.100 | +341.59 |  +33.16 |   +2.32 |   -0.42 |   -0.76 |   -1.07 |
-| $ 1.000 | +3425.81 | +341.59 |  +33.16 |   +5.75 |   +2.32 |   -0.76 |
-| $10.000 | +34268.00 | +3425.81 | +341.59 |  +67.43 |  +33.16 |   +2.32 |
+Constant demand (13,580 tasks/day @ 0.1 QFC); inflation halves per schedule.
 
-## Break-even token price (USD) per hardware tier
+| Miners | Y0 | Y1 | Y2 | Y3 | Y4 |
+|-------:|---------:|---------:|---------:|---------:|---------:|
+| 2 (today) |  2,340.85 |  1,509.92 |  1,094.46 |    886.73 |    782.87 |
+| 10 |    468.17 |    301.98 |    218.89 |    177.35 |    156.57 |
+| 100 |     46.82 |     30.20 |     21.89 |     17.73 |     15.66 |
+| 500 |      9.36 |      6.04 |      4.38 |      3.55 |      3.13 |
+| 1,000 |      4.68 |      3.02 |      2.19 |      1.77 |      1.57 |
 
-At what QFC/USD price does a miner recover daily cost?
+## Per-miner daily gross revenue (USD/day), year 0
 
-| Hardware | Miners | QFC/day | Opex USD/day | Breakeven $ |
-|----------|-------:|--------:|-------------:|------------:|
-| Cheap VPS (4vCPU, CPU-only)  |      1 | 3,426.9 |         0.20 |     $0.0001 |
-| Cheap VPS (4vCPU, CPU-only)  |     10 |   342.7 |         0.20 |     $0.0006 |
-| Cheap VPS (4vCPU, CPU-only)  |    100 |    34.3 |         0.20 |     $0.0058 |
-| Cheap VPS (4vCPU, CPU-only)  |  1,000 |     3.4 |         0.20 |     $0.0576 |
-| Old laptop (2017 MBP Intel)  |      1 | 3,426.9 |         0.16 |     $0.0000 |
-| Old laptop (2017 MBP Intel)  |     10 |   342.7 |         0.16 |     $0.0005 |
-| Old laptop (2017 MBP Intel)  |    100 |    34.3 |         0.16 |     $0.0047 |
-| Old laptop (2017 MBP Intel)  |  1,000 |     3.4 |         0.16 |     $0.0473 |
-| RTX 3060 rig (home PC)       |      1 | 3,426.9 |         1.10 |     $0.0003 |
-| RTX 3060 rig (home PC)       |     10 |   342.7 |         1.10 |     $0.0032 |
-| RTX 3060 rig (home PC)       |    100 |    34.3 |         1.10 |     $0.0322 |
-| RTX 3060 rig (home PC)       |  1,000 |     3.4 |         1.10 |     $0.3223 |
-| Apple M2 Mac mini            |      1 | 3,426.9 |         0.48 |     $0.0001 |
-| Apple M2 Mac mini            |     10 |   342.7 |         0.48 |     $0.0014 |
-| Apple M2 Mac mini            |    100 |    34.3 |         0.48 |     $0.0141 |
-| Apple M2 Mac mini            |  1,000 |     3.4 |         0.48 |     $0.1409 |
-| RTX 4090 rig                 |      1 | 3,426.9 |         3.26 |     $0.0010 |
-| RTX 4090 rig                 |     10 |   342.7 |         3.26 |     $0.0095 |
-| RTX 4090 rig                 |    100 |    34.3 |         3.26 |     $0.0952 |
-| RTX 4090 rig                 |  1,000 |     3.4 |         3.26 |     $0.9524 |
-| A100 40GB (rented per-hour)  |      1 | 3,426.9 |        27.48 |     $0.0080 |
-| A100 40GB (rented per-hour)  |     10 |   342.7 |        27.48 |     $0.0802 |
-| A100 40GB (rented per-hour)  |    100 |    34.3 |        27.48 |     $0.8019 |
-| A100 40GB (rented per-hour)  |  1,000 |     3.4 |        27.48 |     $8.0189 |
+| Miners | $0.01 | $0.05 | $0.10 | $0.50 |
+|-------:|--------:|--------:|--------:|--------:|
+| 2 | $   23.41 | $  117.04 | $  234.08 | $1,170.42 |
+| 10 | $    4.68 | $   23.41 | $   46.82 | $  234.08 |
+| 100 | $    0.47 | $    2.34 | $    4.68 | $   23.41 |
+| 500 | $    0.09 | $    0.47 | $    0.94 | $    4.68 |
+| 1,000 | $    0.05 | $    0.23 | $    0.47 | $    2.34 |
 
-## Scenario: fee share over time (year × task volume)
+## Per-miner daily gross revenue (USD/day), year 4
 
-100 miners, token price irrelevant here. Cell = fees/(fees+inflation). 
-Target is fee share > 50% — the point where the chain is demand-funded.
+| Miners | $0.01 | $0.05 | $0.10 | $0.50 |
+|-------:|--------:|--------:|--------:|--------:|
+| 2 | $    7.83 | $   39.14 | $   78.29 | $  391.43 |
+| 10 | $    1.57 | $    7.83 | $   15.66 | $   78.29 |
+| 100 | $    0.16 | $    0.78 | $    1.57 | $    7.83 |
+| 500 | $    0.03 | $    0.16 | $    0.31 | $    1.57 |
+| 1,000 | $    0.02 | $    0.08 | $    0.16 | $    0.78 |
 
-| Tasks/day | Y0 | Y1 | Y2 | Y3 | Y4 | Y5 |
-|-----------|------|------|------|------|------|------|
-|     1,000 |  0.2% |  0.4% |  0.9% |  1.7% |  3.4% |  3.4% |
-|    10,000 |  2.2% |  4.2% |  8.1% | 15.0% | 26.0% | 26.0% |
-|   100,000 | 18.0% | 30.5% | 46.8% | 63.8% | 77.9% | 77.9% |
-| 1,000,000 | 68.7% | 81.5% | 89.8% | 94.6% | 97.2% | 97.2% |
+## Year-0 breakeven token price (USD) by hardware class
 
-Reading: at today's 8,600 tasks/day, the chain is ~4% fee-funded at year 0 and ~39% fee-funded at year 4 — purely from emission halving, no demand growth. If demand grows to 100k/day by year 2 the chain crosses 50% fee share.
+Price at which daily reward covers daily opex. Bold = the realistic danger zone (n ≥ 500).
 
-## Scenario: demand-side scaling
+| Hardware | Opex $/day | n=2 | n=10 | n=100 | n=500 | n=1,000 |
+|----------|-----------:|--------:|--------:|--------:|--------:|--------:|
+| Idle VPS (4vCPU, already rented) | $0.16 | $0.0001 | $0.0004 | $0.0035 | $0.0176 | $0.0351 |
+| Laptop (already owned, idle) | $0.00 | $0 (free) | $0 (free) | $0 (free) | $0 (free) | $0 (free) |
+| RTX 3060 home rig | $0.99 | $0.0004 | $0.0021 | $0.0211 | **$0.1053** | **$0.2107** |
+| Datacenter GPU (A100-class, rented) | $9.86 | $0.0042 | $0.0211 | $0.2107 | **$1.0534** | **$2.1067** |
 
-Fixed at 100 miners. Rows = task volume. Columns = token price. Inner = USD/day profit on RTX 3060.
+Assumptions: Idle VPS (4vCPU, already rented) — ~$5/mo rental; v2's 'Cheap VPS' was $6/mo; Laptop (already owned, idle) — $0 marginal cost — v2's 'Old laptop' had $0.16/day power; treated as $0 here per refreshed assumption; RTX 3060 home rig — ~$30/mo power (180W @ $0.15/kWh ≈ $19.4/mo + amort); v2 said $1.10/day ≈ $33/mo; Datacenter GPU (A100-class, rented) — $300+/mo; v2's A100 hourly rental was $27.5/day ≈ $825/mo — $300 is the charitable end.
 
-| Tasks/day | $0.00 | $0.01 | $0.10 | $1.00 | $10.00 |
-|-----------|--------|--------|--------|--------|--------|
-|     1,000 |  -1.08 |  -0.84 |  +1.56 | +25.53 | +265.24 |
-|    10,000 |  -1.07 |  -0.75 |  +2.46 | +34.53 | +355.24 |
-|   100,000 |  -0.98 |  +0.15 | +11.46 | +124.53 | +1255.24 |
-| 1,000,000 |  -0.08 |  +9.15 | +101.46 | +1024.53 | +10255.24 |
+## Sanity checks
 
+- PASS — all 25 per-miner reward cells positive and finite
+- PASS — emission multipliers monotone, floor = 1/16 from year 4
+- PASS — baseline fees + inflation = total earnings
+- PASS — recomputed fee share ≈ snapshot value (0.29)
+- PASS — breakeven round-trip for Idle VPS (4vCPU, already rented)
+- PASS — breakeven round-trip for RTX 3060 home rig
+- PASS — breakeven round-trip for Datacenter GPU (A100-class, rented)
+- PASS — n=2 Y0 model (2340.85) matches observed per-miner earnings (2340.84)

--- a/miner-economics/refresh.py
+++ b/miner-economics/refresh.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+QFC Miner Economics Model — v3 refresh (2026-07-04)
+====================================================
+Runs fully OFFLINE. No RPC calls — the testnet is currently in a 3-way
+consensus fork (see project_testnet_consensus_fork), so live numbers are
+unreliable by construction. Inputs are:
+
+  1. snapshots.jsonl — 12 weekly Gap C snapshots (2026-04-13 → 2026-06-28)
+     collected by snapshot.py while the RPC was reachable.
+  2. Protocol constants, verified 2026-07-04 against
+     qfc-core/crates/qfc-types/src/constants.rs (read-only).
+
+Data-quality caveat (repeated in the output header): the chain was
+hard-reset with fresh genesis on 2026-06-18 and again on 2026-06-27, and
+has been running as 3 independent forked chains the entire period. All
+all_time_* counters are discontinuous and each snapshot reflects whichever
+forked node answered. The series is indicative, not authoritative.
+
+Usage:
+  python3 refresh.py            # Markdown to stdout
+  python3 refresh.py --write    # regenerate OUTPUT.md in place
+  python3 refresh.py --json     # raw numbers as JSON
+
+Plain python3, stdlib only.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SNAPSHOTS_PATH = os.path.join(HERE, "snapshots.jsonl")
+OUTPUT_PATH = os.path.join(HERE, "OUTPUT.md")
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# Source of truth: qfc-core/crates/qfc-types/src/constants.rs
+# (verified 2026-07-04; do not edit these without re-checking the file)
+# ---------------------------------------------------------------------------
+BLOCK_REWARD_YEAR_0_QFC = 10.0        # BLOCK_REWARD = 10^19 wei
+MIN_BLOCK_REWARD_QFC = 0.625          # MIN_BLOCK_REWARD, floor after 4 halvings
+HALVING_PERIOD_YEARS = 1              # HALVING_PERIOD_YEARS
+BLOCK_TIME_MS_NOMINAL = 3333          # BLOCK_TIME_MS (nominal; fork-degraded in practice)
+INFERENCE_MINERS_REWARD_PERCENT = 15  # share of block reward routed to inference miners
+FEE_PER_TASK_QFC = 0.1                # observed maxFee on every public task (unchanged since v2)
+
+# NOTE on protocol fee split: FEE_PRODUCER/VOTERS/BURN/TREASURY = 47/28/20/5.
+# That sums to 100 — inference miners get 0% of *gas* fees. The "fees" in this
+# model are inference task fees (maxFee paid by submitters), a separate flow.
+
+
+def emission_multiplier(year: int) -> float:
+    """Block reward for a given year as a fraction of year 0 (halves yearly, floored)."""
+    r = BLOCK_REWARD_YEAR_0_QFC / (2 ** max(0, year))
+    return max(r, MIN_BLOCK_REWARD_QFC) / BLOCK_REWARD_YEAR_0_QFC
+
+
+# ---------------------------------------------------------------------------
+# Snapshot loading (offline baseline)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Snapshot:
+    date: str
+    miners_registered: int
+    daily_tasks: int
+    daily_earnings_qfc: float
+    daily_fees_qfc: float
+    daily_inflation_qfc: float
+    fee_share: float
+    all_time_tasks: int
+    per_miner: list
+
+    @property
+    def usable(self) -> bool:
+        """A snapshot with zero earnings means the RPC was down or the node
+        had just been reset — not that the economy was actually zero."""
+        return self.daily_earnings_qfc > 0
+
+
+def load_snapshots(path: str = SNAPSHOTS_PATH) -> list[Snapshot]:
+    snaps = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            snaps.append(Snapshot(
+                date=d["date"],
+                miners_registered=d.get("miners_registered", 0),
+                daily_tasks=d.get("daily_tasks", 0),
+                daily_earnings_qfc=d.get("daily_earnings_qfc", 0.0),
+                daily_fees_qfc=d.get("daily_fees_qfc_estimated", 0.0),
+                daily_inflation_qfc=d.get("daily_inflation_qfc_estimated", 0.0),
+                fee_share=d.get("fee_share_of_reward", 0.0),
+                all_time_tasks=d.get("all_time_tasks", 0),
+                per_miner=d.get("per_miner", []),
+            ))
+    return snaps
+
+
+# ---------------------------------------------------------------------------
+# Hardware classes (v3 — simplified to the four classes that matter for
+# onboarding; v2's electricity+amortization split collapsed into one
+# monthly-opex number per class, reusing v2 assumptions where sensible)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Hardware:
+    name: str
+    opex_usd_month: float
+    note: str
+
+HARDWARE = [
+    Hardware("Idle VPS (4vCPU, already rented)", 5.0,
+             "~$5/mo rental; v2's 'Cheap VPS' was $6/mo"),
+    Hardware("Laptop (already owned, idle)", 0.0,
+             "$0 marginal cost — v2's 'Old laptop' had $0.16/day power; "
+             "treated as $0 here per refreshed assumption"),
+    Hardware("RTX 3060 home rig", 30.0,
+             "~$30/mo power (180W @ $0.15/kWh ≈ $19.4/mo + amort); v2 said $1.10/day ≈ $33/mo"),
+    Hardware("Datacenter GPU (A100-class, rented)", 300.0,
+             "$300+/mo; v2's A100 hourly rental was $27.5/day ≈ $825/mo — $300 is the charitable end"),
+]
+
+
+def daily_opex_usd(hw: Hardware) -> float:
+    return hw.opex_usd_month * 12 / 365
+
+
+# ---------------------------------------------------------------------------
+# Reward model
+# ---------------------------------------------------------------------------
+# Pool basis (changed vs v2): v2 modeled the single active miner's earnings as
+# the pool. v3 uses the network-wide miner reward pool from the latest usable
+# snapshot: inflation slice scales with the halving schedule; the fee slice is
+# held at observed demand (no growth assumed). Split 1/n — optimistic upper
+# bound for a new miner, since PoC/FLOPS weighting is uneven in practice.
+
+def miner_pool_qfc_day(baseline: Snapshot, year: int) -> tuple[float, float]:
+    """(inflation_pool, fee_pool) network-wide QFC/day for a given year."""
+    return (baseline.daily_inflation_qfc * emission_multiplier(year),
+            baseline.daily_fees_qfc)
+
+
+def per_miner_qfc_day(baseline: Snapshot, n: int, year: int) -> float:
+    infl, fee = miner_pool_qfc_day(baseline, year)
+    return (infl + fee) / n
+
+
+def breakeven_price_usd(daily_reward_qfc: float, opex_usd_day: float) -> float:
+    if daily_reward_qfc <= 0:
+        return float("inf")
+    return opex_usd_day / daily_reward_qfc
+
+
+# ---------------------------------------------------------------------------
+# Sanity checks (deliverable 4)
+# ---------------------------------------------------------------------------
+
+def sanity_check(baseline: Snapshot, miners: list[int], years: list[int],
+                 prices: list[float]) -> list[str]:
+    checks = []
+
+    def ok(cond: bool, label: str):
+        checks.append(("PASS" if cond else "FAIL") + f" — {label}")
+        if not cond:
+            raise AssertionError(f"Sanity check failed: {label}")
+
+    # No negative / NaN rewards anywhere in the grid
+    vals = [per_miner_qfc_day(baseline, n, y) for n in miners for y in years]
+    ok(all(v > 0 and not math.isnan(v) for v in vals),
+       f"all {len(vals)} per-miner reward cells positive and finite")
+
+    # Emission multipliers monotone non-increasing, floored at 1/16
+    ms = [emission_multiplier(y) for y in range(0, 8)]
+    ok(all(a >= b for a, b in zip(ms, ms[1:])) and ms[-1] == 0.0625,
+       "emission multipliers monotone, floor = 1/16 from year 4")
+
+    # Baseline internal consistency: fees + inflation = earnings (±0.01)
+    ok(abs(baseline.daily_fees_qfc + baseline.daily_inflation_qfc
+           - baseline.daily_earnings_qfc) < 0.01,
+       "baseline fees + inflation = total earnings")
+
+    # Observed fee share matches recomputed value (±0.005)
+    ok(abs(baseline.daily_fees_qfc / baseline.daily_earnings_qfc
+           - baseline.fee_share) < 0.005,
+       f"recomputed fee share ≈ snapshot value ({baseline.fee_share})")
+
+    # Breakeven math round-trips: breakeven_price × QFC/day = opex
+    for hw in HARDWARE:
+        opex = daily_opex_usd(hw)
+        if opex == 0:
+            continue
+        r = per_miner_qfc_day(baseline, 100, 0)
+        be = breakeven_price_usd(r, opex)
+        ok(abs(be * r - opex) < 1e-9, f"breakeven round-trip for {hw.name}")
+
+    # n=2 year-0 model output matches the observed per-miner split on 06-28
+    modeled = per_miner_qfc_day(baseline, 2, 0)
+    observed = baseline.per_miner[0]["day_qfc"] if baseline.per_miner else 0
+    ok(abs(modeled - observed) / observed < 0.001,
+       f"n=2 Y0 model ({modeled:.2f}) matches observed per-miner earnings ({observed:.2f})")
+
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+MINERS = [2, 10, 100, 500, 1000]      # n=2 is today
+PRICES = [0.01, 0.05, 0.10, 0.50]
+YEARS = [0, 1, 2, 3, 4]
+
+
+def render(snaps: list[Snapshot]) -> str:
+    usable = [s for s in snaps if s.usable]
+    baseline = usable[-1]
+    out = []
+    w = out.append
+
+    w("# QFC Miner Economics — model output (v3, 2026-07-04)\n")
+    w("> Generated offline — no live RPC (testnet is in a 3-way consensus fork; "
+      "live numbers are unreliable).")
+    w("> Command: `cd miner-economics && python3 refresh.py --write`")
+    w("> Inputs: `snapshots.jsonl` (12 weekly Gap C snapshots, "
+      f"{snaps[0].date} → {snaps[-1].date}) + protocol constants verified against "
+      "`qfc-core/crates/qfc-types/src/constants.rs`.\n")
+    w("> **Data-quality caveat:** the chain was hard-reset with fresh genesis on "
+      "2026-06-18 and again on 2026-06-27, and has run as 3 independent forked "
+      "chains for the whole snapshot period. `all_time_*` counters are "
+      "discontinuous and each snapshot reflects whichever forked node answered. "
+      "Treat the series as indicative, not authoritative.\n")
+
+    # -- snapshot series ----------------------------------------------------
+    w("## Snapshot series (12 weeks)\n")
+    w("| Date | Miners reg. | Tasks/day | Earnings QFC/day | Fee share | All-time tasks | Note |")
+    w("|------|------------:|----------:|-----------------:|----------:|---------------:|------|")
+    notes = {
+        "2026-05-03": "RPC down / node reset — all zeros",
+        "2026-05-10": "RPC down / node reset — all zeros",
+        "2026-05-24": "RPC down / node reset — all zeros",
+        "2026-05-31": "RPC down / node reset — all zeros",
+        "2026-06-07": "validators up, miners deregistered; all_time reset ~06-05",
+        "2026-06-14": "same — no miner earnings",
+        "2026-06-21": "post 06-18 genesis reset; counter restarted",
+        "2026-06-28": "post 06-27 genesis reset; **baseline for v3**",
+    }
+    for s in snaps:
+        fs = f"{s.fee_share:.1%}" if s.usable else "—"
+        w(f"| {s.date} | {s.miners_registered} | {s.daily_tasks:,} | "
+          f"{s.daily_earnings_qfc:,.0f} | {fs} | {s.all_time_tasks:,} | "
+          f"{notes.get(s.date, '')} |")
+    w("")
+    w(f"Only {len(usable)} of {len(snaps)} snapshots are usable (non-zero). "
+      "Observed fee share across usable snapshots: "
+      f"{min(s.fee_share for s in usable):.3f}–{max(s.fee_share for s in usable):.3f} "
+      "(v2 assumed 0.25).\n")
+
+    # -- baseline -----------------------------------------------------------
+    w(f"## Baseline (latest usable snapshot: {baseline.date})\n")
+    w(f"- Active miners: **{len(baseline.per_miner)}** (both earning identical "
+      "amounts — even split)")
+    w(f"- Network miner reward pool: **{baseline.daily_earnings_qfc:,.2f} QFC/day**")
+    w(f"- Daily tasks: {baseline.daily_tasks:,} (sum of per-miner counts; both "
+      "miners report the same 6,790 — possible fork double-count)")
+    w(f"- Fee slice: {baseline.daily_fees_qfc:,.1f} QFC/day "
+      f"({baseline.fee_share:.0%} of reward; fee = {FEE_PER_TASK_QFC} QFC/task)")
+    w(f"- Inflation slice: {baseline.daily_inflation_qfc:,.2f} QFC/day")
+    w("- External paying users: still **zero** (`unique_submitters_last_100` = 0)")
+    w("")
+    w("Model basis (changed vs v2): pool = network-wide miner rewards from this "
+      "snapshot. Inflation slice scales with the halving schedule; fee slice held "
+      "at observed demand (no growth assumed). Split 1/n across miners.\n")
+
+    # -- emission schedule ----------------------------------------------------
+    w("## Emission schedule (protocol constants)\n")
+    w("| Year | QFC/block | × of Y0 | Miner inflation pool QFC/day | Fee share at constant demand |")
+    w("|-----:|----------:|--------:|-----------------------------:|-----------------------------:|")
+    for y in YEARS + [5]:
+        m = emission_multiplier(y)
+        infl, fee = miner_pool_qfc_day(baseline, y)
+        share = fee / (fee + infl)
+        w(f"| {y} | {BLOCK_REWARD_YEAR_0_QFC * m:.4f} | {m:.4f} | {infl:,.1f} | {share:.1%} |")
+    w("")
+    w(f"Nominal block time {BLOCK_TIME_MS_NOMINAL} ms and "
+      f"{INFERENCE_MINERS_REWARD_PERCENT}% inference-miner share imply a "
+      "theoretical Y0 miner pool of "
+      f"{86_400_000 / BLOCK_TIME_MS_NOMINAL * BLOCK_REWARD_YEAR_0_QFC * INFERENCE_MINERS_REWARD_PERCENT / 100:,.0f} "
+      "QFC/day — the observed pool is far below that because the forked chain "
+      "produces blocks erratically. The model uses the *observed* pool.\n")
+
+    # -- per-miner QFC table --------------------------------------------------
+    w("## Per-miner daily reward (QFC/day), by miner count × year\n")
+    w("Constant demand (13,580 tasks/day @ 0.1 QFC); inflation halves per schedule.\n")
+    w("| Miners | " + " | ".join(f"Y{y}" for y in YEARS) + " |")
+    w("|-------:|" + "|".join(["---------:"] * len(YEARS)) + "|")
+    for n in MINERS:
+        cells = " | ".join(f"{per_miner_qfc_day(baseline, n, y):>9,.2f}" for y in YEARS)
+        label = f"{n:,} (today)" if n == 2 else f"{n:,}"
+        w(f"| {label} | {cells} |")
+    w("")
+
+    # -- USD tables -------------------------------------------------------------
+    for y in (0, 4):
+        w(f"## Per-miner daily gross revenue (USD/day), year {y}\n")
+        w("| Miners | " + " | ".join(f"${p:.2f}" for p in PRICES) + " |")
+        w("|-------:|" + "|".join(["--------:"] * len(PRICES)) + "|")
+        for n in MINERS:
+            r = per_miner_qfc_day(baseline, n, y)
+            cells = " | ".join(f"${r * p:>8,.2f}" for p in PRICES)
+            w(f"| {n:,} | {cells} |")
+        w("")
+
+    # -- breakeven --------------------------------------------------------------
+    w("## Year-0 breakeven token price (USD) by hardware class\n")
+    w("Price at which daily reward covers daily opex. Bold = the realistic "
+      "danger zone (n ≥ 500).\n")
+    w("| Hardware | Opex $/day | " + " | ".join(f"n={n:,}" for n in MINERS) + " |")
+    w("|----------|-----------:|" + "|".join(["--------:"] * len(MINERS)) + "|")
+    for hw in HARDWARE:
+        opex = daily_opex_usd(hw)
+        cells = []
+        for n in MINERS:
+            be = breakeven_price_usd(per_miner_qfc_day(baseline, n, 0), opex)
+            s = "$0 (free)" if be == 0 else f"${be:.4f}"
+            if n >= 500 and be >= 0.05:
+                s = f"**{s}**"
+            cells.append(s)
+        w(f"| {hw.name} | ${opex:.2f} | " + " | ".join(cells) + " |")
+    w("")
+    w("Assumptions: " + "; ".join(f"{hw.name} — {hw.note}" for hw in HARDWARE) + ".\n")
+
+    # -- sanity -------------------------------------------------------------------
+    w("## Sanity checks\n")
+    for c in sanity_check(baseline, MINERS, YEARS, PRICES):
+        w(f"- {c}")
+    w("")
+    return "\n".join(out)
+
+
+def as_json(snaps: list[Snapshot]) -> dict:
+    usable = [s for s in snaps if s.usable]
+    baseline = usable[-1]
+    return {
+        "baseline": {
+            "date": baseline.date,
+            "miners_active": len(baseline.per_miner),
+            "daily_tasks": baseline.daily_tasks,
+            "pool_qfc_day": baseline.daily_earnings_qfc,
+            "fee_qfc_day": baseline.daily_fees_qfc,
+            "inflation_qfc_day": baseline.daily_inflation_qfc,
+            "fee_share": baseline.fee_share,
+        },
+        "per_miner_qfc_day": {
+            f"n={n}": {f"y{y}": round(per_miner_qfc_day(baseline, n, y), 4)
+                       for y in YEARS}
+            for n in MINERS
+        },
+        "breakeven_y0_usd": {
+            hw.name: {f"n={n}": round(breakeven_price_usd(
+                per_miner_qfc_day(baseline, n, 0), daily_opex_usd(hw)), 6)
+                for n in MINERS}
+            for hw in HARDWARE
+        },
+    }
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--write", action="store_true", help="regenerate OUTPUT.md")
+    ap.add_argument("--json", action="store_true", help="raw numbers as JSON")
+    ap.add_argument("--snapshots", default=SNAPSHOTS_PATH)
+    args = ap.parse_args()
+
+    snaps = load_snapshots(args.snapshots)
+    if args.json:
+        print(json.dumps(as_json(snaps), indent=2))
+    else:
+        md = render(snaps)
+        if args.write:
+            with open(OUTPUT_PATH, "w") as f:
+                f.write(md)
+            print(f"wrote {OUTPUT_PATH}", file=sys.stderr)
+        else:
+            print(md)


### PR DESCRIPTION
## Summary (Phase 1.1 of 44-L1-MASTER-PLAN)
- New `refresh.py` (stdlib-only, fully offline — no RPC; testnet is mid-fork) regenerates OUTPUT.md from snapshots.jsonl + protocol constants (verified against qfc-core constants.rs: 10 QFC/block, yearly halving, 0.625 floor).
- OUTPUT.md: per-miner QFC/day at n = 2/10/100/500/1000 across years 0–4, USD at $0.01–$0.50, year-0 breakeven per hardware class.
- MINER-ECONOMICS.md v3 section: **conditional pass HOLDS** — verdict rests on the emission schedule, not testnet telemetry; fee share hits 87% by year 4 at zero demand growth. Abandonment gate (">$10 needed") does not trigger: worst realistic cell is $2.11 (rented datacenter GPU at n=1000).
- Data-quality caveats recorded: only 5/12 snapshots usable; 3 counter resets (~06-05 unrecorded, 06-18, 06-27); fee-share rise 0.257→0.29 is an artifact of fork-degraded block production, not fee growth; possible fork double-count on 06-28 miner stats; observed pool ~12× below theoretical 15%-of-emission pool — **re-run after the consensus fix lands before quoting any of this externally**.

## Key numbers
| n miners | QFC/day yr0 | QFC/day yr4 |
|---:|---:|---:|
| 2 (today) | 2,340.85 | — |
| 10 | 468.2 | 156.6 |
| 100 | 46.8 | 15.7 |
| 1000 | 4.68 | 1.57 |

Year-0 breakeven price: laptop $0 · idle VPS $0.0035–0.035 · RTX 3060 $0.021–0.211 · datacenter GPU $0.21–2.11 (n=100→1000).

Reproduce: `cd miner-economics && python3 refresh.py --write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)